### PR TITLE
アプリ名を elt2015 に変えたので必要な箇所を書き直した [closes #35]

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# apuri [![Circle CI](https://circleci.com/gh/yucao24hours/apuri/tree/master.svg?style=svg)](https://circleci.com/gh/yucao24hours/apuri/tree/master)
+# elt2015 [![Circle CI](https://circleci.com/gh/yucao24hours/elt2015.svg?style=svg)](https://circleci.com/gh/yucao24hours/elt2015)
 
 ## 動作確認
 
@@ -9,8 +9,8 @@ GitHub アカウントを使ってログインする仕様のため、事前に 
 その後、セットアップします：
 
 ```sh
-$ git clone git@github.com:yucao24hours/apuri.git
-$ cd apuri
+$ git clone git@github.com:yucao24hours/elt2015.git
+$ cd elt2015
 $ bundle install
 $ （必要に応じて cp config/database.yml.sample config/database.yml をして設定する）
 $ bundle exec rake db:setup db:migrate db:fixtures:load

--- a/app.json
+++ b/app.json
@@ -1,5 +1,5 @@
 {
-  "name":"apuri",
+  "name":"elt2015",
   "scripts":{
     "postdeploy": "FIXTURES='users,exhibits' bundle exec rake db:migrate db:fixtures:load"
   },

--- a/app/views/exhibits/index.html.haml
+++ b/app/views/exhibits/index.html.haml
@@ -1,5 +1,5 @@
 %h2 みんなの出品物一覧
-%p ようこそ apuri へ！
+%p ようこそ elt2015 へ！
 
 %ul.tabs(data-tab)
   %li.tab-title.active

--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -5,7 +5,7 @@
 
     %meta{:name => 'viewport', :content => 'width=device-width, initial-scale=1.0'}
 
-    %title= content_for?(:title) ? yield(:title) : 'apuri'
+    %title= content_for?(:title) ? yield(:title) : 'elt2015'
 
     = stylesheet_link_tag 'application'
     = javascript_include_tag 'vendor/modernizr'

--- a/config/application.rb
+++ b/config/application.rb
@@ -6,7 +6,7 @@ require 'rails/all'
 # you've limited to :test, :development, or :production.
 Bundler.require(*Rails.groups)
 
-module Apuri
+module Elt2015
   class Application < Rails::Application
     # Settings in config/environments/* take precedence over those specified here.
     # Application configuration should go into files in config/initializers

--- a/config/database.yml
+++ b/config/database.yml
@@ -23,13 +23,13 @@ default: &default
 
 development:
   <<: *default
-  database: apuri_development
+  database: elt2015_development
 
   # The specified database role being used to connect to postgres.
   # To create additional roles in postgres see `$ createuser --help`.
   # When left blank, postgres will use the default role. This is
   # the same name as the operating system user that initialized the database.
-  #username: apuri
+  #username: elt2015
 
   # The password associated with the postgres role (username).
   #password:
@@ -57,7 +57,7 @@ development:
 # Do not set this db to the same as development or production.
 test: &test
   <<: *default
-  database: apuri_test
+  database: elt2015_test
 
 # As with config/secrets.yml, you never want to store sensitive information,
 # like your database password, in your source code. If your source code is
@@ -80,9 +80,9 @@ test: &test
 #
 production:
   <<: *default
-  database: apuri_production
-  username: apuri
-  password: <%= ENV['APURI_DATABASE_PASSWORD'] %>
+  database: elt2015_production
+  username: elt2015
+  password: <%= ENV['ELT2015_DATABASE_PASSWORD'] %>
 
 cucumber:
   <<: *test

--- a/config/database.yml.sample
+++ b/config/database.yml.sample
@@ -23,13 +23,13 @@ default: &default
 
 development:
   <<: *default
-  database: apuri_development
+  database: elt2015_development
 
   # The specified database role being used to connect to postgres.
   # To create additional roles in postgres see `$ createuser --help`.
   # When left blank, postgres will use the default role. This is
   # the same name as the operating system user that initialized the database.
-  #username: apuri
+  #username: elt2015
 
   # The password associated with the postgres role (username).
   #password:
@@ -57,7 +57,7 @@ development:
 # Do not set this db to the same as development or production.
 test: &test
   <<: *default
-  database: apuri_test
+  database: elt2015_test
 
 # As with config/secrets.yml, you never want to store sensitive information,
 # like your database password, in your source code. If your source code is
@@ -80,9 +80,9 @@ test: &test
 #
 production:
   <<: *default
-  database: apuri_production
-  username: apuri
-  password: <%= ENV['APURI_DATABASE_PASSWORD'] %>
+  database: elt2015_production
+  username: elt2015
+  password: <%= ENV['ELT2015_DATABASE_PASSWORD'] %>
 
 cucumber:
   <<: *test

--- a/config/initializers/session_store.rb
+++ b/config/initializers/session_store.rb
@@ -1,3 +1,3 @@
 # Be sure to restart your server when you modify this file.
 
-Rails.application.config.session_store :cookie_store, key: '_apuri_session'
+Rails.application.config.session_store :cookie_store, key: '_elt2015_session'


### PR DESCRIPTION
## 概要
アプリ名を apuri から elt2015 に変えたので、それに合わせて修正しました。
あわせて、Heroku にあるステージングの URL も `https://elt2015-staging.herokuapp.com` にしました。（Idobata の description に貼ってあるリンクも更新済み）

## 備考
database.yml もかえてしまったので、手元の DB を drop してもらう必要があります。

This work connects to #35