### PR TITLE
Twitter アカウントでログインできるようにした [closes #28]

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,8 +23,8 @@ $ cp config/application.yml.sample config/application.yml
 # application.yml
 GITHUB_KEY: your key
 GITHUB_SECRET: your secret
-BASIC_AUTH_USERNAME: username # 別途お伝えします
-BASIC_AUTH_PASSWORD: password # 別途お伝えします
+BASIC_AUTH_USERNAME: username
+BASIC_AUTH_PASSWORD: password
 TWITTER_KEY: your_twitter_key
 TWITTER_SECRET: your_twitter_secret
 ```

--- a/README.md
+++ b/README.md
@@ -17,9 +17,16 @@ $ bundle exec rake db:setup db:migrate db:fixtures:load
 $ cp config/application.yml.sample config/application.yml
 ```
 
-セットアップが終わったら、config/application.yml に 1. で取得した key と secret を追記してください。
+セットアップが終わったら、config/application.yml に 1. で取得した key と secret をそれぞれ `GITHUB_KEY` と `GITHUB_SECRET` に追記してください。
 
 ```ruby
+# application.yml
 GITHUB_KEY: your key
 GITHUB_SECRET: your secret
+BASIC_AUTH_USERNAME: username # 別途お伝えします
+BASIC_AUTH_PASSWORD: password # 別途お伝えします
+TWITTER_KEY: your_twitter_key
+TWITTER_SECRET: your_twitter_secret
 ```
+
+※ Twitter アカウントを用いたサインインもできるようにしていますが、こちらは例外的なケースのみで使用することにしています。そのため、動作確認が必要であるなどのケースでない限り セットアップは GitHub のほうだけでかまいません。

--- a/app/controllers/results_controller.rb
+++ b/app/controllers/results_controller.rb
@@ -14,8 +14,8 @@ class ResultsController < ApplicationController
   private
 
   def basic_authentication
-    authenticate_or_request_with_http_basic('ranking') do |username, password|
-      username == ENV['RANKING_USERNAME'] && password == ENV['RANKING_PASSWORD']
+    authenticate_or_request_with_http_basic('result') do |username, password|
+      username == ENV['BASIC_AUTH_USERNAME'] && password == ENV['BASIC_AUTH_PASSWORD']
     end
   end
 end

--- a/app/controllers/user_sessions_controller.rb
+++ b/app/controllers/user_sessions_controller.rb
@@ -1,7 +1,7 @@
 class UserSessionsController < ApplicationController
   before_action :require_login, only: %i(destroy)
 
-  http_basic_authenticate_with(name: ENV['BASIC_AUTH_USERNAME'], password: ENV['BASIC_ENV_PASSWORD'], only: %i(twitter))
+  http_basic_authenticate_with(name: ENV['BASIC_AUTH_USERNAME'], password: ENV['BASIC_AUTH_PASSWORD'], only: :twitter)
 
   def new
   end

--- a/app/controllers/user_sessions_controller.rb
+++ b/app/controllers/user_sessions_controller.rb
@@ -1,6 +1,8 @@
 class UserSessionsController < ApplicationController
   before_action :require_login, only: %i(destroy)
 
+  http_basic_authenticate_with(name: ENV['BASIC_AUTH_USERNAME'], password: ENV['BASIC_ENV_PASSWORD'], only: %i(twitter))
+
   def new
   end
 
@@ -14,5 +16,8 @@ class UserSessionsController < ApplicationController
   def destroy
     reset_session
     redirect_to signin_path, notice: 'サインアウトしました'
+  end
+
+  def twitter
   end
 end

--- a/app/views/user_sessions/twitter.html.haml
+++ b/app/views/user_sessions/twitter.html.haml
@@ -1,0 +1,2 @@
+%h2 Twitter でログイン
+= link_to 'Twitter でサインイン', '/auth/twitter'

--- a/app/views/user_sessions/twitter.html.haml
+++ b/app/views/user_sessions/twitter.html.haml
@@ -1,2 +1,2 @@
-%h2 Twitter でログイン
+%h2 Twitter でサインイン
 = link_to 'Twitter でサインイン', '/auth/twitter'

--- a/app/views/user_sessions/twitter.html.haml
+++ b/app/views/user_sessions/twitter.html.haml
@@ -1,2 +1,4 @@
 %h2 Twitter でサインイン
-= link_to 'Twitter でサインイン', '/auth/twitter'
+= link_to '/auth/twitter', class: 'button radius' do
+  %i.fa.fa-twitter
+  Twitter でサインイン

--- a/config/application.yml.sample
+++ b/config/application.yml.sample
@@ -1,6 +1,6 @@
 GITHUB_KEY: your_github_key
 GITHUB_SECRET: your_github_secret
-RANKING_USERNAME: your_ranking_username
-RANKING_PASSWORD: your_ranking_password
+BASIC_AUTH_USERNAME: username
+BASIC_AUTH_PASSWORD: password
 TWITTER_KEY: your_twitter_key
 TWITTER_SECRET: your_twitter_secret

--- a/config/application.yml.sample
+++ b/config/application.yml.sample
@@ -2,3 +2,5 @@ GITHUB_KEY: your_github_key
 GITHUB_SECRET: your_github_secret
 RANKING_USERNAME: your_ranking_username
 RANKING_PASSWORD: your_ranking_password
+TWITTER_KEY: your_twitter_key
+TWITTER_SECRET: your_twitter_secret

--- a/config/initializers/omniauth.rb
+++ b/config/initializers/omniauth.rb
@@ -1,3 +1,4 @@
 Rails.application.config.middleware.use OmniAuth::Builder do
     provider :github, ENV['GITHUB_KEY'], ENV['GITHUB_SECRET']
+    provider :twitter, ENV['TWITTER_KEY'], ENV['TWITTER_SECRET']
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -4,6 +4,7 @@ Rails.application.routes.draw do
   get '/auth/:provider/callback', to: 'user_sessions#create'
   get 'signin',                   to: 'user_sessions#new'
   delete 'signout',               to: 'user_sessions#destroy'
+  get 'twitter',                  to: 'user_sessions#twitter'
 
   resources :exhibits, only: %i(new create show index)
 


### PR DESCRIPTION
## 概要
Twitter アカウントを使ってもログインができるようにしました。
ただし今回は原則として GitHub アカウントでのログインのみとするため、GitHub ログインの通常ページとは画面を分け、Basic 認証をかけました。

## 背景
前回の tqrk で GitHub および Twitter アカウントでログインできるようにしましたが、どちらもアカウントを持っている人は二重ログインして不正な投票ができてしまう恐れがありました。（結局前回は運用でカバーというか、参加者の良心に任せた形になりました）
それを踏まえて話し合った結果、
「エンジニアの集団のはずだから GitHub アカウントがないということはほぼないだろうし、GitHub アカウントのみという扱いでいいのではないか。
万が一『アカウントがない・忘れた、けど Twitter アカウントならある』という人がいたら、例外的にこの Twitter ログイン機能を使うようにしよう。（もしくはエンジニアならばその場で GitHub アカウントを作っても損はないだろう）」
という結論に至りました。

## TODO
- [x] Basic auth の変数を、ランキングのものと共通にする

## 対応ストーリー
This work connects to #28