### PR TITLE
出品物のタイトルと説明文に文字数制限をつけた [closes #80][closes #78]

### DIFF
--- a/app/models/exhibit.rb
+++ b/app/models/exhibit.rb
@@ -2,7 +2,7 @@ class Exhibit < ActiveRecord::Base
   belongs_to :user
   has_many :votes
 
-  validates :title, presence: true
+  validates :title, presence: true, length: {maximum: 20}
   validates :type,  presence: true
   validates :description, length: {maximum: 30}
 

--- a/app/views/exhibit/votes/new.html.haml
+++ b/app/views/exhibit/votes/new.html.haml
@@ -19,7 +19,7 @@
       = render partial: 'table', locals: { f: f, exhibits: @foods }
 
   = f.label :comment
-  コメントを贈りましょう！（任意です。誹謗中傷や批判的な内容はおやめください。）
+  コメントを贈りましょう！誹謗中傷や批判的な内容はおやめください。（入力は任意です。最大 40 文字入力可能です。）
   = f.text_field :comment
 
   = f.submit class: 'button round success'

--- a/app/views/exhibits/new.html.haml
+++ b/app/views/exhibits/new.html.haml
@@ -10,9 +10,11 @@
   = f.select :type, @exhibits
 
   = f.label :title
+  （入力は必須です。最大 20 文字入力可能です。）
   = f.text_field :title
 
   = f.label :description
+  あなたの作品の魅力を伝える説明文を書いてください。（入力は任意です。最大 40 文字入力可能です。）
   = f.text_area :description
 
   = f.submit class: 'button radius'

--- a/app/views/exhibits/new.html.haml
+++ b/app/views/exhibits/new.html.haml
@@ -14,7 +14,7 @@
   = f.text_field :title
 
   = f.label :description
-  あなたの作品の魅力を伝える説明文を書いてください。（入力は任意です。最大 40 文字入力可能です。）
+  あなたの作品の魅力を伝える説明文を書いてください。（入力は任意です。最大 30 文字入力可能です。）
   = f.text_area :description
 
   = f.submit class: 'button radius'

--- a/test/fixtures/exhibits.yml
+++ b/test/fixtures/exhibits.yml
@@ -29,7 +29,7 @@ mvc:
   type: LightningTalk
   user_id: 1
 ruby_love:
-  title: tokyu の中心で Ruby 愛をさけぶ
+  title: tqrk の中心で Ruby 愛をさけぶ
   description: 叫びます。
   type: LightningTalk
   user_id: 2


### PR DESCRIPTION
## 概要
現状だと、出品物の登録（更新）時に際限なく文字を入力できてしまいますが、レイアウトおよびわかりやすさの観点から、文字数制限をつけました。

ひとまずの値として

- タイトル：20文字
- 説明文：40文字

としています。

## TODO
- [x] #78 も似たような内容の chore なので一緒にやる

## 対応ストーリー
This work connects to #78 
This work connects to #80 
