### PR TITLE
Fix validation for exhibits' description length [closes #124]

### DIFF
--- a/app/models/exhibit.rb
+++ b/app/models/exhibit.rb
@@ -4,7 +4,7 @@ class Exhibit < ActiveRecord::Base
 
   validates :title, presence: true, length: {maximum: 20}
   validates :type,  presence: true
-  validates :description, length: {maximum: 30}
+  validates :description, length: {maximum: 40}
 
   # NOTE ランキングに表示する最低票数 この数値以上の票を集めたもののみ表示する
   RANK_BORDER_NUM = 3.freeze


### PR DESCRIPTION
出品物の説明が、「最大40文字まで」と解説されているのに実際は30文字までのバリデーションがセットされていたので、合わせました。

This work connects to #124